### PR TITLE
fix: B.1.617.2 labelled VOC in Readme.md as in definition file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Variant definitions are subject to change at any time. The latest release can be
 | <a href="variant_yaml/cornstalk-handprint.yml">VUI-21MAR-01</a> | PANGO: B.1.324.1 | First detected in the UK in a traveller from Antigua. |
 | <a href="variant_yaml/mushroom-android.yml">VUI-21MAR-02</a> | PANGO: P.3 | This variant appeared to be closely associated with the Phillipines and widely divergent from anything else upon discovery. |
 | <a href="variant_yaml/habitable-pasty.yml">VUI-21APR-01</a> | PANGO: B.1.617.1 | This variant is reported to be circulating in India and has been exported to other countries. |
-| <a href="variant_yaml/empathy-serve.yml">VUI-21APR-02</a> | PANGO: B.1.617.2 | This variant is reported to be circulating in India and has been exported to other countries. |
+| <a href="variant_yaml/empathy-serve.yml">VOC-21APR-02</a> | PANGO: B.1.617.2 | This variant is reported to be circulating in India and has been exported to other countries. |
 | <a href="variant_yaml/spherical-trial.yml">VUI-21APR-03</a> | PANGO: B.1.617.3 | This variant is reported to be circulating in India and has been exported to other countries. |
 | <a href="variant_yaml/harbor-sprite.yml">E484K</a> | PANGO: Multiple | Catch-all definition to identify sequences with the E484K spike variant |
 | <a href="variant_yaml/dandelion-marshy.yml">VUI-21MAY-01</a> | PANGO: AV.1 | This variant has been observed in a growing cluster in the UK |


### PR DESCRIPTION
Someone must have forgotten to make this change when B.1.617.2 was made VOC from VUI on 7th of May.

Fixes #7 