### PR TITLE
Add WHO labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You can check that files are correct using the `yaml-validator.py` script.
 | ---------------------------- | -------- | ------------ | ------------------------------------------------------------ |
 | unique-id                    | yes      | text         | A unique identifier for this definition file, should never change. |
 | phe-label                    | yes      | text         | The official Public Health England description for this variant, may change over time (e.g. upgrade VUI to VOC) |
+| who-label                    | no       | text         | The official World Health Organisation name for this variant, if any |
 | alternate-names              | no       | list of text | Synonyms for this variant for ease of referencing            |
 | belongs-to-lineage           | no       | list of dict | Lineage descriptions for commonly used lineage naming schemes e.g. PANGO and nextstrain |
 | description                  | yes      | text         | Description of the variant                                   |

--- a/variant_yaml/carnival-shimmy.yml
+++ b/variant_yaml/carnival-shimmy.yml
@@ -1,5 +1,6 @@
 unique-id: carnival-shimmy
 phe-label: VOC-20DEC-02
+who-label: Beta
 alternate-names:
 - VOC202012/02
 - South Africa

--- a/variant_yaml/denture-daughter.yml
+++ b/variant_yaml/denture-daughter.yml
@@ -1,5 +1,6 @@
 unique-id: denture-daughter
 phe-label: VOC-20DEC-01
+who-label: Alpha
 alternate-names:
 - VOC202012/01
 - UK variant

--- a/variant_yaml/empathy-serve.yml
+++ b/variant_yaml/empathy-serve.yml
@@ -1,5 +1,6 @@
 unique-id: empathy-serve
 phe-label: VOC-21APR-02
+who-label: Delta
 alternate-names:
 - India
 - B.1.617 Clade 2

--- a/variant_yaml/glorious-saucy.yml
+++ b/variant_yaml/glorious-saucy.yml
@@ -1,5 +1,6 @@
 unique-id: glorious-saucy
 phe-label: VUI-21FEB-03
+who-label: Eta
 alternate-names:
 - VUI202102/03
 - UK1188

--- a/variant_yaml/habitable-pasty.yml
+++ b/variant_yaml/habitable-pasty.yml
@@ -1,5 +1,6 @@
 unique-id: habitable-pasty
 phe-label: VUI-21APR-01
+who-label: Kappa
 alternate-names:
 - India
 belongs-to-lineage:

--- a/variant_yaml/marbling-doodle.yml
+++ b/variant_yaml/marbling-doodle.yml
@@ -1,5 +1,6 @@
 unique-id: marbling-doodle
 phe-label: VUI-21JAN-01
+who-label: Zeta
 alternate-names:
 - VUI202101/01
 - Brazil 1

--- a/variant_yaml/mushroom-android.yml
+++ b/variant_yaml/mushroom-android.yml
@@ -1,5 +1,6 @@
 unique-id: mushroom-android 
 phe-label: VUI-21MAR-02
+who-label: Theta
 alternate-names:
 - VUI202103/02
 - Philippines

--- a/variant_yaml/slinky-antennae.yml
+++ b/variant_yaml/slinky-antennae.yml
@@ -1,5 +1,6 @@
 unique-id: slinky-antennae
 phe-label: VOC-21JAN-02
+who-label: Gamma
 alternate-names:
 - VOC202101/02
 - Brazil 2


### PR DESCRIPTION
This seems useful, for example to be able to search the repository using a WHO label. I used the convention established in https://github.com/phe-genomics/variant_definitions/blob/161281495a6d815f6e4e0ab8f5cb2b1516f05ab4/variant_yaml/perfume-sprint.yml and added this field to the `README.md`.